### PR TITLE
Fix drag and drop row refresh issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ Pros:
 Cons:
 * You lose some of the out-of-the box functionality of the list: delete, move, edit.
 
+Notes:
+* The current solution uses 2 embedded ForEach loops to render sections and items. When doing it this way, there were some cases where the drop area spacer would stop working when hovering over an item (Meaning, the animation showing you where the item would be inserted did not run). To solve this problem, I had to wrap the `RowDropAreaViewState` in an observable class so that the individual row view (`DDItemRow`) could listen to changes. Another solution, which I have not implemented here, would be to flatten the view model structure so that you have just 1 ForEach loop that can switch between items and sections. This solution worked on a smaller example, but I have not updated this code to give it a try yet. However, it might be a better approach in the long run.
+
+ 
+
 ##### Drag and dropping using a VStack and Transferable
 
 This example explores adding drag and drop to a LazyVStack using Transferable instead of NSItemProvider. I updated the logic to drag and drop between 

--- a/SwiftUIExploration/Examples/DragAndDrop/DragAndDropBetweenListsExampleView.swift
+++ b/SwiftUIExploration/Examples/DragAndDrop/DragAndDropBetweenListsExampleView.swift
@@ -118,11 +118,11 @@ fileprivate struct DropList: View {
                 // An Item was dropped
                 _ = itemProvider.loadObject(ofClass: ItemDragObject.self) { itemDragObject, error in
                     if let error = error {
-                        Log.error("🔴 Failed to load dropped object: '\(error)'")
+                        Log.error("Failed to load dropped object: '\(error)'")
                     } else if let itemDragObject = itemDragObject as? ItemDragObject {
                         executeDroppedAction(item: itemDragObject.item, index: index)
                     } else {
-                        Log.warning("🟠 No item object was passed as part of the drop action.", .dragAndDrop)
+                        Log.warning("No item object was passed as part of the drop action.", .dragAndDrop)
                     }
                 }
             }
@@ -130,16 +130,16 @@ fileprivate struct DropList: View {
                 // Some text was dropped (This can happen on a iPad in split view)
                 _ = itemProvider.loadObject(ofClass: String.self) { string, error in
                     if let error = error {
-                        Log.error("🔴 Failed to load dropped string: '\(error)'")
+                        Log.error("Failed to load dropped string: '\(error)'")
                     } else if let string {
                         executeDroppedAction(item: DDItem(id: UUID().uuidString, title: string), index: index)
                     } else {
-                        Log.warning("🟠 No string was passed as part of the drop action.", .dragAndDrop)
+                        Log.warning("No string was passed as part of the drop action.", .dragAndDrop)
                     }
                 }
             }
             else {
-                Log.warning("🟠 Drop type not supported", .dragAndDrop)
+                Log.warning("Drop type not supported", .dragAndDrop)
             }
         }
     }

--- a/SwiftUIExploration/Examples/DragAndDrop/DragAndDropItemProviderVStackExampleView.swift
+++ b/SwiftUIExploration/Examples/DragAndDrop/DragAndDropItemProviderVStackExampleView.swift
@@ -58,21 +58,9 @@ struct DragAndDropItemProviderVStackExampleView: View {
     }
 
     private func itemRow(item: DDItem, section: DDSection) -> some View {
-        VStack(spacing: 0) {
-            rowDropArea(item: item, dropLocation: .top)
-            ExampleTitleRow(item.title)
-                .padding(.horizontal, Constant.Padding.Custom.outerEdge16)
-                .swipeToDelete {
-                    viewModel.delete(item: item)
-                }
-                .padding(.bottom, Constant.Padding.Custom.rowSpacing8)
-            //.opacity(viewModel.draggedItem?.id == item.id ? 0.20: 1) // TODO: Investigate more as to why this is not working.
-                .getSize(viewModel.rowHeightBinding(for: item))
-                
-            rowDropArea(item: item, dropLocation: .bottom)
-        }
-        .contentShape(Rectangle())
+        DDItemRow(item: item, section: section, viewModel: viewModel, rowDropArea: $viewModel.rowDropArea, isInsertAnimationEnabled: false)
         .onDrag {
+            print("ON DRAG: \(item.title)")
             viewModel.onDrag(item: item)
             return NSItemProvider(object: ItemDragObject(item: item))
         } preview: {
@@ -117,10 +105,13 @@ fileprivate struct DropItemDelegate: DropDelegate {
     
     // MARK: DropDelegate
     func validateDrop(info: DropInfo) -> Bool {
-        return viewModel.draggedItem != nil
+        print("Validate Drop")
+//        return viewModel.draggedItem != nil
+        return true
     }
     
     func dropUpdated(info: DropInfo) -> DropProposal? {
+        print("Drop Updated")
         withAnimation {
             if let destinationItem {
                 viewModel.onHover(over: destinationItem, atLocation: info.location)
@@ -132,6 +123,7 @@ fileprivate struct DropItemDelegate: DropDelegate {
     }
     
     func dropEntered(info: DropInfo) {
+        print("Drop Entered")
     }
     
     func dropExited(info: DropInfo) {
@@ -147,25 +139,53 @@ fileprivate struct DropItemDelegate: DropDelegate {
     
     // MARK: Private
     func performDrop(info: DropInfo) -> Bool {
-        guard let draggedItem =  viewModel.draggedItem else {
-            Log.warning("No item to drag and drop.", .dragAndDrop)
-            return false
-        }
-        withAnimation {
-            if let destinationItem {
-                viewModel.onDrop(item: draggedItem,
-                                 onto: destinationItem,
-                                 atLocation: info.location)
-            } else if let destinationSection {
-                viewModel.onDrop(item: draggedItem, onto: destinationSection)
-            } else {
-                assertionFailure("Missing destination item or section")
-                Log.warning("Missing destination item or section")
+        
+        loadDragItem(info: info) { draggedItem in
+            guard let draggedItem else {
+                Log.warning("No item to drag and drop.", .dragAndDrop)
+                return
             }
-            
+            DispatchQueue.main.async {
+                withAnimation {
+                    if let destinationItem {
+                        viewModel.onDrop(item: draggedItem,
+                                         onto: destinationItem,
+                                         atLocation: info.location)
+                    } else if let destinationSection {
+                        viewModel.onDrop(item: draggedItem, onto: destinationSection)
+                    } else {
+                        assertionFailure("Missing destination item or section")
+                        Log.warning("Missing destination item or section")
+                    }
+                    
+                }
+                viewModel.draggedItem = nil
+            }
         }
-        viewModel.draggedItem = nil
+                     
         return true
+    }
+    
+    private func loadDragItem(info: DropInfo, completion: @escaping (DDItem?) -> Void) {
+        // TODO: We should iterate through all item providers (instead of just taking the first one)
+        // TODO: Make this code common with the List drag and drop code.
+        // TODO: Remove draggedItem from viewModel
+        guard info.hasItemsConforming(to: [ItemDragObject.typeIdentifier]),
+              let itemProvider = info.itemProviders(for: [ItemDragObject.typeIdentifier])[safe: 0] else {
+            completion(nil)
+            return
+        }
+        itemProvider.loadObject(ofClass: ItemDragObject.self) { itemDragObject, error in
+            if let error = error {
+                Log.error("🔴 Failed to load dropped object: '\(error)'")
+                completion(nil)
+            } else if let itemDragObject = itemDragObject as? ItemDragObject {
+                completion(itemDragObject.item)
+            } else {
+                Log.warning("🟠 No item object was passed as part of the drop action.", .dragAndDrop)
+                completion(nil)
+            }
+        }
     }
 }
 
@@ -177,3 +197,39 @@ struct DragAndDropItemProviderVStackExampleView_Previews: PreviewProvider {
     }
 }
 
+
+fileprivate struct DDItemRow: View {
+    var item: DDItem
+    var section: DDSection
+    var viewModel: DragAndDropSectionViewModel
+    @Binding var rowDropArea: RowDropAreaViewState?
+    
+    var isInsertAnimationEnabled: Bool
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            rowDropArea(item: item, dropLocation: .top)
+            ExampleTitleRow(item.title)
+                .padding(.horizontal, Constant.Padding.Custom.outerEdge16)
+                .swipeToDelete {
+                    viewModel.delete(item: item)
+                }
+                .padding(.bottom, Constant.Padding.Custom.rowSpacing8)
+            //.opacity(viewModel.draggedItem?.id == item.id ? 0.20: 1) // TODO: Investigate more as to why this is not working.
+                .getSize(viewModel.rowHeightBinding(for: item))
+            
+            rowDropArea(item: item, dropLocation: .bottom)
+        }
+        .contentShape(Rectangle())
+    }
+    
+    @ViewBuilder
+    private func rowDropArea(item: DDItem, dropLocation: RowDropLocation) -> some View {
+        if let rowDropArea = rowDropArea,
+           rowDropArea.item.id == item.id,
+           rowDropArea.dropLocation == dropLocation {
+            Color.clear
+                .frame(height: rowDropArea.height)
+        }
+    }
+}

--- a/SwiftUIExploration/Examples/DragAndDrop/DragAndDropSectionViewModel.swift
+++ b/SwiftUIExploration/Examples/DragAndDrop/DragAndDropSectionViewModel.swift
@@ -32,7 +32,7 @@ struct RowDropAreaViewState {
 class DragAndDropSectionViewModel: ObservableObject {
     // MARK: Properties
     @Published private (set) var sections: [DDSection]
-    @Published private (set) var rowDropArea: RowDropAreaViewState? // Defines the spacer that will be inserted before or after a row to simulate making space to drop the dragged item.
+    @Published  var rowDropArea: RowDropAreaViewState? // Defines the spacer that will be inserted before or after a row to simulate making space to drop the dragged item.
     @Published var draggedItem: DDItem?
     @Published var highlightedEmptySection: DDSection? = nil
     private var rowSizes: [String:CGSize] = [:]

--- a/SwiftUIExploration/Examples/DragAndDrop/DragAndDropSectionViewModel.swift
+++ b/SwiftUIExploration/Examples/DragAndDrop/DragAndDropSectionViewModel.swift
@@ -14,6 +14,20 @@ enum RowDropLocation {
     case bottom
 }
 
+// This is a wrapper around the view state so that item view can listen to changes and redraw properly.
+// If we just use `RowDropAreaViewState` by itself, drop area will not show up. To reproduce the issue:
+// 1) Drag item 1 in section 2
+// 2) Drag item 2 in section 2
+// => At that point you would expect the view to move so you can see where you are inserting item 2. Without this class it's not.
+// Note: Another solution would have been to flatten the view model so that instead of having 2 embedded ForEach, you just have a flat structure.
+class RowDropAreaViewModel: ObservableObject {
+    @Published var state: RowDropAreaViewState?
+    
+    init(state: RowDropAreaViewState?) {
+        self.state = state
+    }
+}
+
 /// Defines where a space should be displayed when dragging and dropping an item
 struct RowDropAreaViewState {
     let item: DDItem
@@ -32,7 +46,7 @@ struct RowDropAreaViewState {
 class DragAndDropSectionViewModel: ObservableObject {
     // MARK: Properties
     @Published private (set) var sections: [DDSection]
-    @Published  var rowDropArea: RowDropAreaViewState? // Defines the spacer that will be inserted before or after a row to simulate making space to drop the dragged item.
+    @Published  var rowDropArea: RowDropAreaViewModel // Defines the spacer that will be inserted before or after a row to simulate making space to drop the dragged item.
     @Published var draggedItem: DDItem?
     @Published var highlightedEmptySection: DDSection? = nil
     private var rowSizes: [String:CGSize] = [:]
@@ -40,6 +54,7 @@ class DragAndDropSectionViewModel: ObservableObject {
     // MARK: Lifecycle
     init(sections: [DDSection]) {
         self.sections = sections
+        self.rowDropArea = .init(state: nil)
     }
     
     // MARK: Public
@@ -71,14 +86,14 @@ class DragAndDropSectionViewModel: ObservableObject {
         let hoverLocation = calculateRowDropLocation(y: location.y,
                                                      draggedRowHeight: draggedItemHeight,
                                                      destinationRowHeight: rowHeightBinding(for: dropItem).height.wrappedValue )
-        rowDropArea = RowDropAreaViewState(item: dropItem,
-                                           dropLocation: hoverLocation,
-                                           height: draggedItemHeight)
+        rowDropArea.state = RowDropAreaViewState(item: dropItem,
+                                                            dropLocation: hoverLocation,
+                                                            height: draggedItemHeight)
     }
     
     /// Gets called when the dragged item is not over another item anymore
     func onHoverExited(dropItem: DDItem) {
-        rowDropArea = RowDropAreaViewState(item: dropItem, dropLocation: .none, height: .zero)
+        rowDropArea.state = RowDropAreaViewState(item: dropItem, dropLocation: .none, height: .zero)
     }
     
     /// Gets called when the dragged item hover over an empty section drop area
@@ -161,7 +176,7 @@ class DragAndDropSectionViewModel: ObservableObject {
     /// Calculates where an item should be inserted based on the position of the dragged item over the destination item.
     private func calculateRowDropLocation(y: CGFloat, draggedRowHeight: CGFloat, destinationRowHeight: CGFloat) -> RowDropLocation {
         var center: CGFloat = destinationRowHeight / 2
-        if let rowDropArea,
+        if let rowDropArea = rowDropArea.state,
            rowDropArea.dropLocation == .top {
             center = center + draggedRowHeight
         }
@@ -219,7 +234,7 @@ class DragAndDropSectionViewModel: ObservableObject {
     }
     
     private func resetEnvironment() {
-        rowDropArea = nil
+        rowDropArea.state = nil
         highlightedEmptySection = nil
         draggedItem = nil
     }

--- a/SwiftUIExploration/Examples/DragAndDrop/DragAndDropTransferableVStackExampleView.swift
+++ b/SwiftUIExploration/Examples/DragAndDrop/DragAndDropTransferableVStackExampleView.swift
@@ -68,7 +68,7 @@ struct DragAndDropTransferableVStackExampleView: View {
     private func itemRow(item: DDItem, section: DDSection) -> some View {
         DDItemRow(item: item, section: section,
                   viewModel: viewModel,
-                  rowDropArea: $viewModel.rowDropArea,
+                  rowDropArea: viewModel.rowDropArea,
                   isInsertAnimationEnabled: isInsertAnimationEnabled)
         .draggable(item, preview: {
             ExampleTitleRow(item.title)
@@ -82,7 +82,7 @@ struct DragAndDropTransferableVStackExampleView: View {
         
     @ViewBuilder
     private func rowDropArea(item: DDItem, dropLocation: RowDropLocation) -> some View {
-        if let rowDropArea = viewModel.rowDropArea,
+        if let rowDropArea = viewModel.rowDropArea.state,
            rowDropArea.item.id == item.id,
            rowDropArea.dropLocation == dropLocation {
             Color.clear
@@ -125,7 +125,7 @@ struct DragAndDropTransferableVStackExampleView: View {
     func emptyListDropAction(dropAreaSection: DDSection, draggedItems: [DDItem]) -> Bool {
         Log.info("Dropping item '\(draggedItems[safe: 0]?.title ?? "")' on empty section '\(dropAreaSection.title)'", .dragAndDrop)
         if draggedItems.count > 1 {
-            Log.warning("🟠 Error: Dragging and dropping multiple items is not supported, only the first item will be dropped.")
+            Log.warning("Error: Dragging and dropping multiple items is not supported, only the first item will be dropped.")
         }
 
         guard let draggedItem = draggedItems[safe: 0] else {
@@ -188,7 +188,7 @@ fileprivate struct DDItemRow: View {
     var item: DDItem
     var section: DDSection
     var viewModel: DragAndDropSectionViewModel
-    @Binding var rowDropArea: RowDropAreaViewState?
+    @ObservedObject var rowDropArea: RowDropAreaViewModel
     
     var isInsertAnimationEnabled: Bool
     
@@ -198,7 +198,7 @@ fileprivate struct DDItemRow: View {
                 rowDropArea(item: item, dropLocation: .top)
             }
             ExampleTitleRow(item.title)
-                .scaleEffect(!isInsertAnimationEnabled && item.id == rowDropArea?.item.id && rowDropArea?.dropLocation != RowDropLocation.none ? 1.03: 1)
+                .scaleEffect(!isInsertAnimationEnabled && item.id == rowDropArea.state?.item.id && rowDropArea.state?.dropLocation != RowDropLocation.none ? 1.03: 1)
                 .padding(.horizontal, Constant.Padding.Custom.outerEdge16)
                 .swipeToDelete {
                     viewModel.delete(item: item)
@@ -214,7 +214,7 @@ fileprivate struct DDItemRow: View {
     
     @ViewBuilder
     private func rowDropArea(item: DDItem, dropLocation: RowDropLocation) -> some View {
-        if let rowDropArea,
+        if let rowDropArea = rowDropArea.state,
            rowDropArea.item.id == item.id,
            rowDropArea.dropLocation == dropLocation {
             Color.clear

--- a/SwiftUIExploration/Examples/DragAndDrop/DragAndDropTransferableVStackExampleView.swift
+++ b/SwiftUIExploration/Examples/DragAndDrop/DragAndDropTransferableVStackExampleView.swift
@@ -66,23 +66,10 @@ struct DragAndDropTransferableVStackExampleView: View {
     }
     
     private func itemRow(item: DDItem, section: DDSection) -> some View {
-        VStack(spacing: 0) {
-            if isInsertAnimationEnabled {
-                rowDropArea(item: item, dropLocation: .top)
-            }
-            ExampleTitleRow(item.title)
-                .scaleEffect(!isInsertAnimationEnabled && item.id == viewModel.rowDropArea?.item.id && viewModel.rowDropArea?.dropLocation != RowDropLocation.none ? 1.03: 1)
-                .padding(.horizontal, Constant.Padding.Custom.outerEdge16)
-                .swipeToDelete {
-                    viewModel.delete(item: item)
-                }
-                .padding(.bottom, Constant.Padding.Custom.rowSpacing8)
-                .getSize(viewModel.rowHeightBinding(for: item))
-            if isInsertAnimationEnabled {
-                rowDropArea(item: item, dropLocation: .bottom)
-            }
-        }
-        .contentShape(Rectangle())
+        DDItemRow(item: item, section: section,
+                  viewModel: viewModel,
+                  rowDropArea: $viewModel.rowDropArea,
+                  isInsertAnimationEnabled: isInsertAnimationEnabled)
         .draggable(item, preview: {
             ExampleTitleRow(item.title)
                 .dragPreview()
@@ -193,5 +180,45 @@ struct DragAndDropTransferableVStackExampleView: View {
 struct DragAndDropTransferableVStackExampleView_Previews: PreviewProvider {
     static var previews: some View {
         DragAndDropTransferableVStackExampleView()
+    }
+}
+
+
+fileprivate struct DDItemRow: View {
+    var item: DDItem
+    var section: DDSection
+    var viewModel: DragAndDropSectionViewModel
+    @Binding var rowDropArea: RowDropAreaViewState?
+    
+    var isInsertAnimationEnabled: Bool
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if isInsertAnimationEnabled {
+                rowDropArea(item: item, dropLocation: .top)
+            }
+            ExampleTitleRow(item.title)
+                .scaleEffect(!isInsertAnimationEnabled && item.id == rowDropArea?.item.id && rowDropArea?.dropLocation != RowDropLocation.none ? 1.03: 1)
+                .padding(.horizontal, Constant.Padding.Custom.outerEdge16)
+                .swipeToDelete {
+                    viewModel.delete(item: item)
+                }
+                .padding(.bottom, Constant.Padding.Custom.rowSpacing8)
+                .getSize(viewModel.rowHeightBinding(for: item))
+            if isInsertAnimationEnabled {
+                rowDropArea(item: item, dropLocation: .bottom)
+            }
+        }
+        .contentShape(Rectangle())
+    }
+    
+    @ViewBuilder
+    private func rowDropArea(item: DDItem, dropLocation: RowDropLocation) -> some View {
+        if let rowDropArea,
+           rowDropArea.item.id == item.id,
+           rowDropArea.dropLocation == dropLocation {
+            Color.clear
+                .frame(height: rowDropArea.height)
+        }
     }
 }

--- a/SwiftUIExploration/Examples/DragAndDrop/ItemDragObject.swift
+++ b/SwiftUIExploration/Examples/DragAndDrop/ItemDragObject.swift
@@ -35,7 +35,7 @@ extension ItemDragObject: NSItemProviderWriting {
             completionHandler(encodedObject, nil)
         } catch {
             
-            Log.error("🔴 Error Encoding - '\(error)'", .dragAndDrop)
+            Log.error("Error Encoding - '\(error)'", .dragAndDrop)
             completionHandler(nil, error)
         }
         
@@ -55,7 +55,7 @@ extension ItemDragObject: NSItemProviderReading {
         do {
             return try decoder.decode(ItemDragObject.self, from: data)
         } catch {
-            Log.error("🔴 Error Decoding - '\(error)'", .dragAndDrop)
+            Log.error("Error Decoding - '\(error)'", .dragAndDrop)
             throw error
         }
     }


### PR DESCRIPTION
## What's new/changed

**1) Fix View Update**
In some scenarios, the item row view stopped being refreshed. The drop area spacer would stop working when hovering over an item (Meaning, the animation showing you where the item would be inserted did not run). 

To solve this problem, I had to wrap the `RowDropAreaViewState` in an observable class so that the individual row view (`DDItemRow`) could listen to changes. This fixes some of the issues, but you can tell that the view is not getting refreshed properly every time as the `onDrag()` event is not always getting called.  This seems to happen to items dragged outside their original sections. 

**2) Fix drop code**
Since the `.onDrag()` method is not always getting called, I am now relying on the "DropInfo" to figure out which item is getting dropped. I kept the "DraggedItem" in the view model for now as I want to test the flat structure approach before fixing all this code.
 
## Future

After playing with other examples on the side, it seems that having a flat list (using only 1 ForEach) might solve all potential issues. This will be for another day. 

## Screenshots

n/a